### PR TITLE
Add system notification as a possible notification sound

### DIFF
--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -19,7 +19,9 @@
 	<string name="notification">Benachrichtigung</string>
 	<string name="notification_sound">Benachrichtigungston</string>
 	<string name="notification_sound_desc">Der Ton der Benachrichtigung.</string>
-	
+	<string name="notification_default">System-Benachrichtigung</string>
+	<string name="notification_no_sound">Kein Ton</string>
+			
 	<string name="notification_vibrate">Vibration bei Benachrichtigung</string>
 	<string name="notification_vibrate_desc">Soll der der Timer vibrieren?</string>
 	

--- a/res/values-fr/strings.xml
+++ b/res/values-fr/strings.xml
@@ -19,6 +19,8 @@
 	<string name="notification">Notification</string>
 	<string name="notification_sound">Avertissement sonore</string>
 	<string name="notification_sound_desc">Effet sonore de la notification.</string>
+	<string name="notification_default">Avertissement standard</string>
+	<string name="notification_no_sound">Silence</string>
 	
 	<string name="notification_vibrate">Notification vibrante</string>
 	<string name="notification_vibrate_desc">Faire vibrer le téléphone pour la notification.</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -7,7 +7,7 @@
 	<string name="Notification">Tea time!</string>
 	<string name="InputTitle">Hour:Min:Sec</string>
 
-	<string name="warning_text">The phone is in silent mode! Notification vibration and sound will be supressed.</string>
+	<string name="warning_text">The phone is in silent mode! Notification vibration and sound will be suppressed.</string>
 	<string name="warning_title">Warning</string>
 	<string name="warning_button">Ok</string>
 	
@@ -19,7 +19,9 @@
 	<string name="notification">Notification</string>
 	<string name="notification_sound">Notification Diddy</string>
 	<string name="notification_sound_desc">The notification\'s sound effects.</string>
-	
+	<string name="notification_default">System default</string>
+	<string name="notification_no_sound">No sound</string>
+		
 	<string name="notification_vibrate">Notification Vibrate</string>
 	<string name="notification_vibrate_desc">Should the timer notification Vibrate.</string>
 	
@@ -54,7 +56,8 @@
 	<string name="about_details_licence">TeaTimer is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or any later version.</string>
 	<string name="about_details_url">http://www.gnu.org/licenses/gpl.html</string>
 	<string name="about_site">Get the latest version of the source code on Github.</string>
-	<string name="about_site_url">https://github.com/ralphleon/TeaTimer</string>	
+	<string name="about_site_url">https://github.com/ralphleon/TeaTimer</string>
+		
 	
 	
 		

--- a/src/goo/TeaTimer/TimerPrefActivity.java
+++ b/src/goo/TeaTimer/TimerPrefActivity.java
@@ -6,7 +6,7 @@ import android.os.Bundle;
 import android.preference.ListPreference;
 import android.preference.PreferenceActivity;
 import android.provider.MediaStore;
-import android.util.Log;
+//import android.util.Log;
 
 public class TimerPrefActivity extends PreferenceActivity 
 {
@@ -49,15 +49,18 @@ public class TimerPrefActivity extends PreferenceActivity
 	        	i++;
         	}
         
-	        cursor.close();   
+	        cursor.close();
 		}
         
-    	CharSequence [] entries = {"No Sound","Big Ben"};
-    	CharSequence [] entryValues = {"","android.resource://goo.TeaTimer/" + R.raw.big_ben};
-    	
-    	//Default value
-    	if(tone.getValue() == null) tone.setValue((String)entryValues[1]);
-    	
+        CharSequence [] entries = { getResources().getText(R.string.notification_no_sound),
+                                    getResources().getText(R.string.notification_default),
+                                    "Big Ben"};
+        CharSequence [] entryValues = {"", "SYSTEM_DEFAULT", "android.resource://goo.TeaTimer/" + R.raw.big_ben};
+
+        //Default value
+        if (tone.getValue() == null){
+            tone.setValue((String)entryValues[2]);
+        }
     	if( items != null && items.length > 0){
     		tone.setEntries(concat(entries,items));
     		tone.setEntryValues(concat(entryValues,itemUris));

--- a/src/goo/TeaTimer/TimerReceiver.java
+++ b/src/goo/TeaTimer/TimerReceiver.java
@@ -65,14 +65,24 @@ public class TimerReceiver extends BroadcastReceiver
         }
         
         // Play a sound!
-        if(notificationUri != ""){
-			Uri uri = Uri.parse(notificationUri);
-	      	notification.sound = uri;
+        if(!notificationUri.toString().equals("")){
+            if (notificationUri.toString().equals("SYSTEM_DEFAULT")){
+                Log.v(TAG, "Using default sound for notification");
+                notification.defaults |= Notification.DEFAULT_SOUND;
+            }
+            else{
+                Log.v(TAG, "Using sound " + notificationUri.toString() + " for notification");
+                Uri uri = Uri.parse(notificationUri);
+                notification.sound = uri;
+            }
         }
-        
+        else{
+            Log.v(TAG, "No sound is played");
+        }
+
         notification.flags |= Notification.FLAG_AUTO_CANCEL;
-        
-      	Intent intent = new Intent(context,TimerActivity.class);
+
+        Intent intent = new Intent(context,TimerActivity.class);
         PendingIntent contentIntent = PendingIntent.getActivity(context,  0,intent, Intent.FLAG_ACTIVITY_NEW_TASK);
 
         notification.setLatestEventInfo(context, text,
@@ -117,6 +127,6 @@ public class TimerReceiver extends BroadcastReceiver
 
         // Show notification
         mNM.notify(0, notification);
-	}
+    }
 
 }


### PR DESCRIPTION
This change adds another entry to the list of notification sounds:
System default. When this option is chosen, the Tea Timer will use the
notification ringtone that is currently selected for system
notifications.
